### PR TITLE
Add some command line arguments to simplify automation

### DIFF
--- a/gamemanager.cpp
+++ b/gamemanager.cpp
@@ -25,7 +25,8 @@
 GameManager::GameManager(QQuickView *view) : QObject(view),
     m_view(view),
     m_roundsPlayed(0),
-    m_ticksLeft(-1)
+    m_ticksLeft(-1),
+    m_isGameRunning(false)
 {
 
     // Add QML objects
@@ -109,6 +110,9 @@ void GameManager::startRound()
     if (m_players.isEmpty()) {
         return;
     }
+
+    m_isGameRunning = true;
+    emit isGameRunningChanged();
 
     resetPositions();
 
@@ -357,6 +361,8 @@ void GameManager::togglePause()
 void GameManager::stopGame()
 {
     m_tickTimer.stop();
+    m_isGameRunning = false;
+    emit isGameRunningChanged();
 
     QMutableListIterator<Player*> it(m_players);
     while(it.hasNext()) {

--- a/gamemanager.h
+++ b/gamemanager.h
@@ -20,6 +20,7 @@ class GameManager : public QObject
 {
     Q_OBJECT
 
+    Q_PROPERTY(bool isGameRunning READ isGameRunning NOTIFY isGameRunningChanged)
     Q_PROPERTY(int roundsPlayed READ roundsPlayed() NOTIFY roundsPlayedChanged())
     Q_PROPERTY(int ticksLeft READ ticksLeft NOTIFY tick)
     Q_PROPERTY(QList<QObject*> players READ players NOTIFY playersChanged)
@@ -38,6 +39,7 @@ public:
 
     Q_INVOKABLE QString version();
 
+    bool isGameRunning() const { return m_isGameRunning; }
     int ticksLeft() const { return m_ticksLeft; }
 
     QList<QObject *> players() const;
@@ -57,6 +59,7 @@ public slots:
     int roundsPlayed() { return m_roundsPlayed; }
 
 signals:
+    void isGameRunningChanged();
     void roundOver();
     void clientConnected();
     void roundsPlayedChanged();
@@ -81,6 +84,7 @@ private:
     QTcpServer m_server;
     int m_roundsPlayed;
     int m_ticksLeft;
+    bool m_isGameRunning;
 };
 
 #endif // GAMEMANAGER_H

--- a/qml/EndScreen.qml
+++ b/qml/EndScreen.qml
@@ -88,7 +88,6 @@ Rectangle {
                 return
             }
             GameManager.stopGame()
-            startScreen.opacity = 1
         }
         text: "Restart"
     }

--- a/qml/StartScreen.qml
+++ b/qml/StartScreen.qml
@@ -263,7 +263,6 @@ Item {
                 return
             }
             GameManager.resetScores()
-            startScreen.opacity = 0
             GameManager.startRound()
         }
     }

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -28,7 +28,6 @@ Rectangle {
     Keys.onLeftPressed: userMove("LEFT")
     Keys.onEscapePressed: {
         GameManager.stopGame();
-        startScreen.opacity = 1
     }
 
     Keys.onPressed: {
@@ -364,7 +363,7 @@ Rectangle {
 
     StartScreen {
         id: startScreen
-        opacity: 1
+        opacity: !GameManager.isGameRunning
         //onOpacityChanged: gameFilter.opacity = opacity
     }
 


### PR DESCRIPTION
This adds `--start-at <num>` as a command line argument as requested on IRC by NiteLite (and me), the game will automatically start when the specified number of clients have connected.

I added `-i <ms>` or alternatively `--tick-interval <ms>` as well, allowing a custom tick interval between 10 and 1000 milliseconds, could be useful to lower it to either reduce the time it takes to do test runs, or increase it so it's easier to see what the bots do.

`--quit-on-finish` does what it says, it's not very useful right now but will come in handy when someone adds code to log round results to file or stdout.

It's not the best structured code with connects and lambdas in main, but it works.
